### PR TITLE
feat: 최근 뉴스 불러오기 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'imgnews.pstatic.net',
       },
+      {
+        protocol: 'https',
+        hostname: 'mimgnews.pstatic.net',
+      },
     ],
   },
 };

--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Theme } from '@radix-ui/themes';
+import { Providers } from '@/components/providers';
+import MswInit from '@/components/msw-init';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+export function ClientLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MswInit />
+      <Providers>
+        <Theme>{children}</Theme>
+      </Providers>
+    </QueryClientProvider>
+  );
+} 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import '@radix-ui/themes/styles.css';
-import { Theme } from '@radix-ui/themes';
-import { Providers } from '@/components/providers';
-import MswInit from '@/components/msw-init';
+import { ClientLayout } from '@/app/client-layout';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -35,10 +33,7 @@ export default function RootLayout({
         />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <MswInit />
-        <Providers>
-          <Theme>{children}</Theme>
-        </Providers>
+        <ClientLayout>{children}</ClientLayout>
       </body>
     </html>
   );

--- a/src/app/recent-news/page.tsx
+++ b/src/app/recent-news/page.tsx
@@ -47,6 +47,10 @@ export default function RecentNewsPage() {
 
   const newsItems = data?.pages.flatMap((page) => page.news) ?? [];
 
+  const handleNewsClick = (id: string) => {
+    router.push(`/news/${id}`);
+  };
+
   if (isLoading) {
     return <div>Loading...</div>;
   }
@@ -77,6 +81,7 @@ export default function RecentNewsPage() {
             press={item.publisher}
             publishedAt={new Date(item.published_at)}
             imageUrl={item.thumbnail_url}
+            onClick={() => handleNewsClick(item.id)}
           />
         ))}
         <div ref={loadMoreRef} style={{ height: '20px' }} />
@@ -92,6 +97,7 @@ interface RecentNewsCardProps {
   press: string;
   publishedAt: Date;
   imageUrl: string;
+  onClick: () => void;
 }
 
 const Thumbnail = ({ size = 140, imageUrl }: { size?: number; imageUrl: string }) => {
@@ -125,7 +131,14 @@ const Thumbnail = ({ size = 140, imageUrl }: { size?: number; imageUrl: string }
   );
 };
 
-const RecentNewsCard = ({ id, title, press, publishedAt, imageUrl }: RecentNewsCardProps) => {
+const RecentNewsCard = ({
+  id,
+  title,
+  press,
+  publishedAt,
+  imageUrl,
+  onClick,
+}: RecentNewsCardProps) => {
   return (
     <div
       style={{
@@ -137,6 +150,7 @@ const RecentNewsCard = ({ id, title, press, publishedAt, imageUrl }: RecentNewsC
         minHeight: '140px',
         gap: '12px',
       }}
+      onClick={onClick}
     >
       <Thumbnail imageUrl={imageUrl} />
       <div

--- a/src/app/recent-news/page.tsx
+++ b/src/app/recent-news/page.tsx
@@ -3,32 +3,40 @@ import { NavigateBar } from '@/components/ui/navigate-bar';
 import styles from './page.module.css';
 import { getTimeAgo } from '@/utils/datetime';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { Spacing } from '@/components/ui/spacing';
+import { useNews } from '@/hooks/useNews';
 
 export default function RecentNewsPage() {
   const router = useRouter();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useNews(10);
+  const loadMoreRef = useRef<HTMLDivElement>(null);
 
-  const newsItems: RecentNewsCardProps[] = [
-    {
-      id: 1,
-      title: '비상경제대응TF, 개헌 등 이재명 대선후보 기자간담회 주요 내용은?',
-      press: '중앙일보',
-      publishedAt: new Date('2024-05-01'),
-      imageUrl:
-        'https://imgnews.pstatic.net/image/047/2025/06/03/0002476033_001_20250603204709447.jpg?type=w860',
-    },
-    {
-      id: 2,
-      title: '비상경제대응TF, 개헌 등 이재명 대선후보 기자간담회 주요 내용은?',
-      press: '중앙일보',
-      publishedAt: new Date('2024-05-01'),
-      imageUrl:
-        'https://imgnews.pstatic.net/image/047/2025/06/03/0002476033_001_20250603204709447.jpg?type=w860',
-    },
-  ];
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+        if (first.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    if (loadMoreRef.current) {
+      observer.observe(loadMoreRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const newsItems = data?.pages.flatMap((page) => page.news) ?? [];
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <>
@@ -49,15 +57,24 @@ export default function RecentNewsPage() {
       <Spacing size={56} />
       <div className={styles.page}>
         {newsItems.map((item) => (
-          <RecentNewsCard key={item.id} {...item} />
+          <RecentNewsCard
+            key={item.id}
+            id={item.id}
+            title={item.title}
+            press={item.publisher}
+            publishedAt={new Date(item.published_at)}
+            imageUrl={item.thumbnail_url}
+          />
         ))}
+        <div ref={loadMoreRef} style={{ height: '20px' }} />
+        {isFetchingNextPage && <div>불러오는 중...</div>}
       </div>
     </>
   );
 }
 
 interface RecentNewsCardProps {
-  id: number;
+  id: string;
   title: string;
   press: string;
   publishedAt: Date;
@@ -95,7 +112,7 @@ const Thumbnail = ({ size = 140, imageUrl }: { size?: number; imageUrl: string }
   );
 };
 
-const RecentNewsCard = ({ title, press, publishedAt, imageUrl }: RecentNewsCardProps) => {
+const RecentNewsCard = ({ id, title, press, publishedAt, imageUrl }: RecentNewsCardProps) => {
   return (
     <div
       style={{

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,9 @@
+export const API_BASE_URL = 'https://cuteshrew.com';
+
+export const API_ENDPOINTS = {
+  NEWS: {
+    LIST: `${API_BASE_URL}/api/news`,
+    DETAIL: (id: string) => `${API_BASE_URL}/api/news/${id}`,
+    COMPARISON: (id: string) => `${API_BASE_URL}/api/news/comparisons/${id}`,
+  },
+} as const; 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+} 

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -38,9 +38,11 @@ export function useNews(size: number = 10, keyword?: string) {
   return useInfiniteQuery({
     queryKey: ['news', keyword],
     queryFn: ({ pageParam = 1 }) => fetchNews({ page: pageParam, size, keyword }),
-    getNextPageParam: (_, allPages) => {
-      const nextPage = allPages.length + 1;
-      return nextPage;
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.news.length === 0) {
+        return undefined
+      }
+      return allPages.length + 1;
     },
   });
 }

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,0 +1,46 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+interface NewsItem {
+  id: string;
+  title: string;
+  published_at: string;
+  thumbnail_url: string;
+  publisher: string;
+}
+
+interface NewsResponse {
+  news: NewsItem[];
+}
+
+interface NewsParams {
+  page: number;
+  size: number;
+  keyword?: string;
+}
+
+const fetchNews = async ({ page, size, keyword }: NewsParams) => {
+  const response = await fetch('https://34.64.170.41/api/news', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ page, size, keyword }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch news');
+  }
+
+  return response.json() as Promise<NewsResponse>;
+};
+
+export function useNews(size: number = 10, keyword?: string) {
+  return useInfiniteQuery({
+    queryKey: ['news', keyword],
+    queryFn: ({ pageParam = 1 }) => fetchNews({ page: pageParam, size, keyword }),
+    getNextPageParam: (_, allPages) => {
+      const nextPage = allPages.length + 1;
+      return nextPage;
+    },
+  });
+}

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,4 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { newsRepository } from '@/repositories/newsRepository';
+import type { NewsResponse } from '@/repositories/newsRepository';
 
 interface NewsItem {
   id: string;
@@ -8,18 +10,14 @@ interface NewsItem {
   publisher: string;
 }
 
-interface NewsResponse {
-  news: NewsItem[];
-}
-
 interface NewsParams {
   page: number;
   size: number;
   keyword?: string;
 }
 
-const fetchNews = async ({ page, size, keyword }: NewsParams) => {
-  const response = await fetch('https://34.64.170.41/api/news', {
+const fetchNews = async ({ page = 0, size = 10, keyword }: NewsParams) => {
+  const response = await fetch('https://cuteshrew.com/api/news', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -37,12 +35,13 @@ const fetchNews = async ({ page, size, keyword }: NewsParams) => {
 export function useNews(size: number = 10, keyword?: string) {
   return useInfiniteQuery({
     queryKey: ['news', keyword],
-    queryFn: ({ pageParam = 1 }) => fetchNews({ page: pageParam, size, keyword }),
+    queryFn: ({ pageParam = 0 }) => 
+      newsRepository.getNewsList({ page: pageParam, size, keyword }),
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.news.length === 0) {
-        return undefined
+        return undefined;
       }
-      return allPages.length + 1;
+      return allPages.length;
     },
   });
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -80,14 +80,14 @@ export const handlers = [
     return HttpResponse.json({
       news: [
         {
-          id: 'news-1',
+          id: '550e8400-e29b-41d4-a716-446655440000',
           title: 'AI가 바꿀 미래 일자리',
           published_at: '2024-06-04T09:00:00Z',
           thumbnail_url: '/images/ai.jpg',
           publisher: '경향신문',
         },
         {
-          id: 'news-2',
+          id: '550e8400-e29b-41d4-a716-446655440001',
           title: '부동산 시장, 다시 오를까?',
           published_at: '2024-06-04T08:00:00Z',
           thumbnail_url: '/images/house.jpg',
@@ -99,7 +99,7 @@ export const handlers = [
 
   http.get('https://34.64.170.41/api/news/:id', () => {
     return HttpResponse.json({
-      id: 'news-1',
+      id: '550e8400-e29b-41d4-a716-446655440000',
       title: 'AI가 바꿀 미래 일자리',
       published_at: '2024-06-04T09:00:00Z',
       source: '경향신문',
@@ -120,9 +120,9 @@ export const handlers = [
 
   http.get('https://34.64.170.41/api/news/comparisons/:id', () => {
     return HttpResponse.json({
-      id: 'cmp-1',
+      id: '550e8400-e29b-41d4-a716-446655440088',
       left_news: {
-        id: 'news-1',
+        id: '550e8400-e29b-41d4-a716-446655440000',
         title: '진보 언론: 경제 위기, 정부 대책은?',
         published_at: '2024-06-04T07:00:00Z',
         source: '한겨레',
@@ -136,7 +136,7 @@ export const handlers = [
         bad_comment: '재원 마련 방안이 부족함',
       },
       right_news: {
-        id: 'news-2',
+        id: '550e8400-e29b-41d4-a716-446655440001',
         title: '보수 언론: 경제 위기, 야당 책임론',
         published_at: '2024-06-04T07:00:00Z',
         source: '조선일보',

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -81,17 +81,17 @@ export const handlers = [
       news: [
         {
           id: '550e8400-e29b-41d4-a716-446655440000',
-          title: 'AI가 바꿀 미래 일자리',
-          published_at: '2024-06-04T09:00:00Z',
-          thumbnail_url: '/images/ai.jpg',
-          publisher: '경향신문',
+          title: '尹 뽑은 유권자 10명 중 4명 "국민의힘, 계엄 반성하고 탄핵 받아들였어야"',
+          published_at: '2025-06-09T09:00:00Z',
+          thumbnail_url: 'https://imgnews.pstatic.net/image/002/2025/06/09/0002392251_001_20250609203310827.jpg?type=w860',
+          publisher: '프레시안',
         },
         {
           id: '550e8400-e29b-41d4-a716-446655440001',
-          title: '부동산 시장, 다시 오를까?',
-          published_at: '2024-06-04T08:00:00Z',
-          thumbnail_url: '/images/house.jpg',
-          publisher: '중앙일보',
+          title: "'이준석 의원직 제명하라' 청원에 동의 폭주‥닷새 만에 40만명 돌파",
+          published_at: '2025-06-09T20:22:00Z',
+          thumbnail_url: 'https://mimgnews.pstatic.net/image/origin/214/2025/06/09/1429134.jpg?type=ofullfill220_150',
+          publisher: 'MBC',
         },
       ],
     });

--- a/src/repositories/newsRepository.ts
+++ b/src/repositories/newsRepository.ts
@@ -1,0 +1,69 @@
+import { API_ENDPOINTS } from '@/constants/api';
+
+export interface NewsItem {
+  id: string;
+  title: string;
+  published_at: string;
+  thumbnail_url: string;
+  publisher: string;
+}
+
+export interface NewsResponse {
+  news: NewsItem[];
+}
+
+export interface NewsParams {
+  page: number;
+  size: number;
+  keyword?: string;
+}
+
+class NewsRepository {
+  async getNewsList({ page = 0, size = 10, keyword }: NewsParams): Promise<NewsResponse> {
+    const response = await fetch(API_ENDPOINTS.NEWS.LIST, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ page, size, keyword }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch news');
+    }
+
+    return response.json();
+  }
+
+  async getNewsDetail(id: string) {
+    const response = await fetch(API_ENDPOINTS.NEWS.DETAIL(id), {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch news detail');
+    }
+
+    return response.json();
+  }
+
+  async getNewsComparison(id: string) {
+    const response = await fetch(API_ENDPOINTS.NEWS.COMPARISON(id), {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch news comparison');
+    }
+
+    return response.json();
+  }
+}
+
+export const newsRepository = new NewsRepository();


### PR DESCRIPTION
## 한일
- 뉴스 불러오기
  - 모킹 데이터 수정
  - api.ts, newsRepository.ts 구현
    - 현재 cuteshrew.com 주소 사용
  - 무한 스크롤 디바운싱
![localhost_3000_recent-news(Pixel 7)](https://github.com/user-attachments/assets/4f13e4cf-a5d9-43dd-9318-b8b1cb9b7754)
